### PR TITLE
Re-export the (>$<) operator

### DIFF
--- a/src/Control/Tracer.hs
+++ b/src/Control/Tracer.hs
@@ -71,11 +71,12 @@ module Control.Tracer
     , squelchUnless
     -- * Re-export of Contravariant
     , Contravariant(..)
+    , (>$<)
     ) where
 
 import           Control.Arrow ((|||), (&&&), arr, runKleisli)
 import           Control.Category ((>>>))
-import           Data.Functor.Contravariant (Contravariant (..))
+import           Data.Functor.Contravariant (Contravariant (..), (>$<))
 import           Debug.Trace (traceM)
 
 import qualified Control.Tracer.Arrow as Arrow


### PR DESCRIPTION
The `>$<` operator works well with `(.)` unlike the infix version of `contramap`.