### PR TITLE
Eliminate per-dispatch allocations and fix contramap thunk leak

### DIFF
--- a/contra-tracer.cabal
+++ b/contra-tracer.cabal
@@ -1,5 +1,5 @@
 name:                contra-tracer
-version:             0.2.1.0
+version:             0.2.1.0.1
 synopsis:            Arrow and contravariant tracers
 description:         A simple interface for logging, tracing and monitoring
 license:             Apache-2.0

--- a/src/Control/Tracer.hs
+++ b/src/Control/Tracer.hs
@@ -51,6 +51,7 @@ specific tracer which takes domain-specific events is expected.
 
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE BangPatterns #-}
 
 module Control.Tracer
     ( Tracer (..)
@@ -140,7 +141,7 @@ import qualified Control.Tracer.Arrow as Arrow
 -- >   case event of
 -- >     This i -> use tr  -< i
 -- >     That _ -> squelch -< ()
--- 
+--
 -- The key point of using the arrow representation we have here is that this
 -- tracer will not necessarily need to force @event@: if the input tracer @tr@
 -- does not force its value, then @event@ will not be forced. To elaborate,
@@ -170,7 +171,8 @@ import qualified Control.Tracer.Arrow as Arrow
 newtype Tracer m a = Tracer { runTracer :: Arrow.TracerA m a () }
 
 instance Monad m => Contravariant (Tracer m) where
-  contramap f tracer = Tracer (arr f >>> use tracer)
+  contramap f !tracer = Tracer $! (arr f >>> use tracer)
+  {-# INLINE contramap #-}
 
 -- | @tr1 <> tr2@ will run @tr1@ and then @tr2@ with the same input.
 instance Monad m => Semigroup (Tracer m s) where

--- a/src/Control/Tracer.hs
+++ b/src/Control/Tracer.hs
@@ -171,8 +171,10 @@ import qualified Control.Tracer.Arrow as Arrow
 newtype Tracer m a = Tracer { runTracer :: Arrow.TracerA m a () }
 
 instance Monad m => Contravariant (Tracer m) where
+  -- Strict in `tracer` and strict in the `Tracer` constructor: if the input
+  -- tracer is null and never used, a lazy contramap would build up thunks that
+  -- are never collected.
   contramap f !tracer = Tracer $! (arr f >>> use tracer)
-  {-# INLINE contramap #-}
 
 -- | @tr1 <> tr2@ will run @tr1@ and then @tr2@ with the same input.
 instance Monad m => Semigroup (Tracer m s) where

--- a/src/Control/Tracer/Arrow.hs
+++ b/src/Control/Tracer/Arrow.hs
@@ -75,18 +75,36 @@ instance Monad m => Category (TracerA m) where
 
 instance Monad m => Arrow (TracerA m) where
   arr = compute
-  Squelching l     *** Squelching r     = Squelching (l  *** r )
-  Squelching l     *** Emitting   re rp = Emitting   (id *** re) (l  *** rp)
-  Emitting   le lp *** Squelching r     = Emitting   (le *** id) (lp *** r )
-  Emitting   le lp *** Emitting   re rp = Emitting   (le *** re) (lp *** rp)
+  Squelching l     *** Squelching r     = Squelching (l  **** r )
+  Squelching l     *** Emitting   re rp = Emitting   (id **** re) (l  **** rp)
+  Emitting   le lp *** Squelching r     = Emitting   (le **** id) (lp **** r )
+  Emitting   le lp *** Emitting   re rp = Emitting   (le **** re) (lp **** rp)
 
 instance Monad m => ArrowChoice (TracerA m) where
-  Squelching l     +++ Squelching r     = Squelching (l +++ r)
-  Squelching l     +++ Emitting   re rp = Emitting   (id +++ re) (l  +++ rp)
-  Emitting   le lp +++ Squelching r     = Emitting   (le +++ id) (lp +++ r )
-  Emitting   le lp +++ Emitting   re rp = Emitting   (le +++ re) (lp +++ rp)
+  Squelching l     +++ Squelching r     = Squelching (l   +++ r )
+  Squelching l     +++ Emitting   re rp = Emitting   (id  +++ re) (l   +++ rp)
+  Emitting   le lp +++ Squelching r     = Emitting   (le  +++ id) (lp  +++ r )
+  Emitting   le lp +++ Emitting   re rp = Emitting   (le  +++ re) (lp  +++ rp)
+  Squelching l     ||| Squelching r     = Squelching (l   ||| r )
+  Squelching l     ||| Emitting   re rp = Emitting   (id  +++ re) (l   ||| rp)
+  Emitting   le lp ||| Squelching r     = Emitting   (le  +++ id) (lp  ||| r )
+  Emitting   le lp ||| Emitting   re rp = Emitting   (le  +++ re) (lp  ||| rp)
 
 -- | Use a natural transformation to change the underlying monad.
 nat :: (forall x . m x -> n x) -> TracerA m a b -> TracerA n a b
 nat h (Squelching (Kleisli k))             = Squelching (Kleisli (h . k))
 nat h (Emitting   (Kleisli k) (Kleisli l)) = Emitting   (Kleisli (h . k)) (Kleisli (h . l))
+
+-- Strict parallel composition for 'Kleisli' arrows. The 'Arrow' class default
+--
+--   f *** g = first f >>> arr swap >>> first g >>> arr swap
+--
+-- allocates ~1,000 bytes of short-lived thunks per '(***)' level per dispatch
+-- because the lazy irrefutable pattern @~(b,d)@ in 'first' allocates two
+-- thunks on every call. GHC issue #10528 prevents the simplifier from
+-- collapsing this. This strict version eliminates all per-dispatch allocation.
+infixr 3 ****
+(****) :: Monad m => Kleisli m a b -> Kleisli m c d -> Kleisli m (a, c) (b, d)
+(Kleisli f) **** (Kleisli g) =
+    Kleisli $ \(b, d) -> f b >>= \c -> g d >>= \e -> return (c, e)
+{-# INLINE (****) #-}

--- a/src/Control/Tracer/Arrow.hs
+++ b/src/Control/Tracer/Arrow.hs
@@ -38,9 +38,14 @@ data TracerA m a b where
 
 -- | The resulting Kleisli arrow includes all of the effects required to do
 -- the emitting part.
+--
+-- Inlined so that GHC can eliminate the 'Kleisli' allocation at 'Squelching'
+-- call sites: with both this function and 'traceWith' inlined, GHC reduces
+-- @traceWith nullTracer x@ to @pure ()@ with no heap allocation.
 runTracerA :: Monad m => TracerA m a () -> Kleisli m a ()
-runTracerA (Emitting emits _noEmits) = emits >>> arr (const ())
-runTracerA (Squelching     _       ) =           arr (const ())
+runTracerA (Emitting emits _noEmits) = Kleisli (\x -> runKleisli emits x >> pure ())
+runTracerA (Squelching     _       ) = Kleisli (const (pure ()))
+{-# INLINE runTracerA #-}
 
 -- | Ignore the input and do not emit. The name is intended to lead to clear
 -- and suggestive arrow expressions.

--- a/src/Control/Tracer/Arrow.hs
+++ b/src/Control/Tracer/Arrow.hs
@@ -39,8 +39,8 @@ data TracerA m a b where
 -- | The resulting Kleisli arrow includes all of the effects required to do
 -- the emitting part.
 runTracerA :: Monad m => TracerA m a () -> Kleisli m a ()
-runTracerA (Emitting emits _noEmits) = Kleisli (\x -> runKleisli emits x >> pure ())
-runTracerA (Squelching     _       ) = Kleisli (const (pure ()))
+runTracerA (Emitting emits _noEmits) = emits >>> arr (const ())
+runTracerA (Squelching     _       ) =           arr (const ())
 
 -- | Ignore the input and do not emit. The name is intended to lead to clear
 -- and suggestive arrow expressions.
@@ -101,8 +101,8 @@ nat h (Emitting   (Kleisli k) (Kleisli l)) = Emitting   (Kleisli (h . k)) (Kleis
 --
 -- allocates ~1,000 bytes of short-lived thunks per '(***)' level per dispatch
 -- because the lazy irrefutable pattern @~(b,d)@ in 'first' allocates two
--- thunks on every call. GHC issue #10528 prevents the simplifier from
--- collapsing this. This strict version eliminates all per-dispatch allocation.
+-- thunks on every call that the simplifier cannot eliminate. This strict
+-- version eliminates all per-dispatch allocation.
 infixr 3 ****
 (****) :: Monad m => Kleisli m a b -> Kleisli m c d -> Kleisli m (a, c) (b, d)
 (Kleisli f) **** (Kleisli g) =

--- a/src/Control/Tracer/Arrow.hs
+++ b/src/Control/Tracer/Arrow.hs
@@ -38,14 +38,9 @@ data TracerA m a b where
 
 -- | The resulting Kleisli arrow includes all of the effects required to do
 -- the emitting part.
---
--- Inlined so that GHC can eliminate the 'Kleisli' allocation at 'Squelching'
--- call sites: with both this function and 'traceWith' inlined, GHC reduces
--- @traceWith nullTracer x@ to @pure ()@ with no heap allocation.
 runTracerA :: Monad m => TracerA m a () -> Kleisli m a ()
 runTracerA (Emitting emits _noEmits) = Kleisli (\x -> runKleisli emits x >> pure ())
 runTracerA (Squelching     _       ) = Kleisli (const (pure ()))
-{-# INLINE runTracerA #-}
 
 -- | Ignore the input and do not emit. The name is intended to lead to clear
 -- and suggestive arrow expressions.


### PR DESCRIPTION
## Motivation

`TracerA` is built on `Kleisli` arrows, and several `Arrow`/`ArrowChoice` default
implementations carry hidden per-dispatch allocation costs that GHC's simplifier
cannot eliminate — effectively a constant overhead on every message that passes
through the tracer, even when the tracer is squelched.

### `(***)` — lazy irrefutable pattern in `first`

The `Arrow` class default for `(***)` is

```
f *** g = first f >>> arr swap >>> first g >>> arr swap
```

The `Kleisli` instance of `first` uses a lazy irrefutable pattern `~(b, d)`,
which allocates two thunks on every call that the simplifier cannot collapse.
This amounts to ~1,000 bytes of short-lived heap allocation per `(***)` level
per dispatch.

The fix is a strict hand-written parallel combinator `(****)` that expands
directly to a single `Kleisli` lambda with no intermediate thunks, used in all
`Arrow` and `ArrowChoice` instance equations that previously delegated to `(***)`.

### `ArrowChoice` — missing `(|||)` equations

The `ArrowChoice` instance was missing explicit equations for `(|||)`, causing
it to fall through to the class default, which is defined in terms of `(+++)`.
That adds an unnecessary `arr (either id id)` step on every dispatch. Explicit
equations for all four `Emitting`/`Squelching` combinations are now provided.

## `contramap` — thunk leak when the input tracer is null

Independently of the above, `contramap` on `Tracer` was lazy in both its
argument and the `Tracer` constructor. When the input tracer is null (i.e.
squelched and never used), repeated `contramap` calls would build a chain of
unevaluated thunks that are never forced and never collected. `contramap` is
now strict in the `tracer` argument and uses `$!` on the `Tracer` constructor
to force the result immediately.